### PR TITLE
Update lux

### DIFF
--- a/data/lux
+++ b/data/lux
@@ -1,3 +1,4 @@
 https://bitbucket.org/kfj/pv/downloads/lux-master-x86_64.AppImage
 # This URL provides an AppImage built from lux master and is updated
 # at irregular intervals. Versioned AppImages reside in the same folder.
+# The latest upload has lux 1.1.8 and updated metadata.xml


### PR DESCRIPTION
The latest upload has an AppImage of lux 1.1.8 built on ubuntu 20.04 instead of 18.04. It also has a new version of metadata.xml